### PR TITLE
Faster dev start

### DIFF
--- a/lib/default-render-document.js
+++ b/lib/default-render-document.js
@@ -1,14 +1,12 @@
 const Document = require('boiler-room-runner/dist/server/Document')
 const { createElement } = require('react')
 const { renderToStaticMarkup } = require('react-dom/server')
-const { keys } = Object
 
-module.exports = (assets) => {
-  const assetList = keys(assets)
-  const styles = assetList.filter((asset) => asset.match(/\.css$/))
-  const scripts = assetList.filter((asset) => asset.match(/\.js$/))
+module.exports = ({ assets }) => {
+  const styles = assets.filter((asset) => asset.match(/\.css$/))
+  const scripts = assets.filter((asset) => asset.match(/\.js$/))
 
-  return () => (
+  return (
     '<!doctype html>' + renderToStaticMarkup(
       createElement(Document, {
         styles,

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -1,3 +1,4 @@
+const MagicHTMLPlugin = require('../magic-html-plugin')
 const WebpackDevServer = require('webpack-dev-server')
 const webpack = require('webpack')
 const { assign, keys } = Object
@@ -17,7 +18,10 @@ module.exports = ({
   devConfig
 }) => {
   const syncedClientConfig = assign({}, clientConfig, {
-    entry: addDevServerToEntries(clientConfig.entry, port)
+    entry: addDevServerToEntries(clientConfig.entry, port),
+    plugins: (clientConfig.plugins || []).concat(
+      new MagicHTMLPlugin()
+    )
   })
   const syncedDevConfig = assign({}, devConfig, {
     publicPath: clientConfig.output.publicPath,

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,6 +1,5 @@
 const build = require('./build')
 const { join } = require('path')
-const { writeFile } = require('fs')
 const assetsFromStats = require('./assets-from-stats')
 
 const PROD = process.env.NODE_ENV === 'production'
@@ -15,39 +14,34 @@ module.exports = ({
   devConfig,
   outputDir
 }) => {
-  build({ serverConfig, clientConfig }, ({ serverStats, clientStats }) => {
-    const { compilation: clientCompilation } = clientStats
-    const { compilation: serverCompilation } = serverStats
+  if (PROD) {
+    build({ serverConfig, clientConfig }, ({ serverStats, clientStats }) => {
+      const { compilation: clientCompilation } = clientStats
+      const { compilation: serverCompilation } = serverStats
 
-    const { outputOptions: clientOutput } = clientCompilation
+      const { outputOptions: clientOutput } = clientCompilation
 
-    const { outputOptions: serverOutput } = serverCompilation
-    const { path, filename } = serverOutput
+      const { outputOptions: serverOutput } = serverCompilation
+      const { path, filename } = serverOutput
 
-    const appModule = require(join(path, filename))
-    const initApp = appModule.default || appModule
+      const appModule = require(join(path, filename))
+      const initApp = appModule.default || appModule
 
-    const assets = assetsFromStats(clientStats, clientOutput.publicPath)
+      const assets = assetsFromStats(clientStats, clientOutput.publicPath)
 
-    Promise.resolve({ assets }).then(initApp).then((app) => {
-      if (PROD) {
+      Promise.resolve({ assets }).then(initApp).then((app) => {
         prodServer({
           port,
           staticDir: clientOutput.path,
           app
         })
-      } else {
-        const indexContent = app.empty()
-
-        writeFile(join(clientOutput.path, 'index.html'), indexContent, () => {
-          devServer({
-            port,
-            clientConfig,
-            devConfig,
-            outputDir
-          })
-        })
-      }
+      })
     })
-  })
+  } else {
+    devServer({
+      port,
+      clientConfig,
+      devConfig
+    })
+  }
 }

--- a/magic-html-plugin.js
+++ b/magic-html-plugin.js
@@ -1,0 +1,33 @@
+const { keys } = Object
+const defaultRender = require('./lib/default-render-document')
+
+module.exports = class {
+  constructor ({ render = defaultRender } = {}) {
+    this.render = render
+  }
+
+  apply (compiler) {
+    compiler.plugin('emit', ({
+      outputOptions,
+      assets
+    }, callback) => {
+      const { render } = this
+      const { publicPath } = outputOptions
+      const appAssets = keys(assets).map((asset) => (
+        publicPath + asset
+      ))
+
+      const html = render({ assets: appAssets })
+
+      assets['index.html'] = {
+        source () {
+          return html
+        },
+        size () {
+          return html.length
+        }
+      }
+      callback()
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
+    "boiler-room-runner": "^1.0.0-10",
     "connect": "^3.4.1",
     "connect-logger": "0.0.1",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
Previously dev start went:

1 Build for client
2 Build for server
3 Require the module created by the server compilation
4 Grab the stats for the client compilation and pass this info the server module
5 Render the "empty" version of the app using the server module, save this file as `index.html` to the output dir.
6 Start the dev server (which will run another client compilation)

**3 Builds**

Now we have:

1 Start the dev server
2 The Magic HTML Plugin can get the compilation stats during the emit compilation lifecycle phase
3 Magic HTML Plugin passes stats to a render document function which produces "content-less" html with all assets injected
4 Magic HTML Plugin adds this to assets emitted

**1 Build**

TODO:
Allow users to pas an alternative path to a module which exports a custom a function which will take the assets list and return "content-less" HTML.