### PR TITLE
Improve sass config for easy hero-ui compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postcss-loader": "^0.9.1",
     "progress-bar-webpack-plugin": "^1.8.0",
     "react-addons-test-utils": "^15.3.2",
+    "resolve-url-loader": "^1.6.0",
     "sass-loader": "^4.0.0",
     "serve-static": "^1.11.1",
     "snazzy": "^5.0.0",

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -34,7 +34,7 @@ const loaders = [
     test: /\.scss$/,
     loader: cssExtractor.extract(
       'style',
-      'css!sass!postcss'
+      'css!postcss!resolve-url!sass?sourceMap'
     )
   },
   {


### PR DESCRIPTION
Two things happening here:

1. The loader order was switched to run `sass` then `postcss`. This resolves issues where SASS style comments were causing build errors.

2. Added `resolve-url-loader` to help with `hero-ui` compatibility in loading assets correctly. We we're getting build errors telling us that images couldn't be located, because in `hero-ui` the image URL's are relative to the `.scss` file from which they are referenced.