### PR TITLE
Bind 0.0.0.0 instead of localhost

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -45,5 +45,5 @@ module.exports = ({
   new WebpackDevServer(
     compiler,
     syncedDevConfig
-  ).listen(port, 'localhost')
+  ).listen(port, '0.0.0.0')
 }


### PR DESCRIPTION
When running `npm run start` from a docker container, it doesn't allow
outside requests since we're binding only localhost.

This change seems to fix it since requests are passed to it.