### PR TITLE
Pipe linting task correctly, add '.' to compiler extensions

### DIFF
--- a/scripts/lint/index.js
+++ b/scripts/lint/index.js
@@ -13,16 +13,14 @@ const lint = spawn(
 const format = spawn(
   process.execPath,
   [require.resolve('snazzy/bin/cmd')],
-  { stdio: 'inherit' }
+  { stdio: ['pipe', process.stdout, process.stderr] }
 )
-lint.stdout.pipe(format)
+lint.stdout.pipe(format.stdin)
 
 lint.on('exit', (code, signal) => {
-  process.on('exit', () => {
-    if (signal) {
-      process.kill(process.pid, signal)
-    } else {
-      process.exit(code)
-    }
-  })
+  if (signal) {
+    process.kill(process.pid, signal)
+  } else {
+    process.exit(code)
+  }
 })

--- a/scripts/test/compiler.js
+++ b/scripts/test/compiler.js
@@ -1,10 +1,7 @@
 const extensions = require('../../config/extensions')
 const opts = require('../../config/babel')
 
-require('babel-register')(opts)
-
 function noop () { return {} }
-
 [].concat(
   extensions['css'],
   extensions['sass'],
@@ -13,5 +10,7 @@ function noop () { return {} }
   extensions['images'],
   extensions['video']
 ).forEach((ext) => {
-  require.extensions[ext] = noop
+  require.extensions[`.${ext}`] = noop
 })
+
+require('babel-register')(opts)


### PR DESCRIPTION
Pretty weird, only came up when the `--input-dir` option was set to anything other than `.` ... Anyway, this is more explicit when it comes to piping the linting stuff anyhow.