### PR TITLE
Whitelist all non-js files for Webpack bundling

### DIFF
--- a/config/webpack.server.config.js
+++ b/config/webpack.server.config.js
@@ -4,7 +4,9 @@ const entry = {
   server: './server.js'
 }
 
-const externals = [nodeExternals()]
+const externals = [nodeExternals({
+  whitelist: [/\.(?!(?:jsx?|json)$).{1,5}$/i]
+})]
 
 const loaders = [
   {


### PR DESCRIPTION
I could target just css and scss, but that seems a little too exclusive. I'd rather just target everything.