### PR TITLE
Use kexec

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-const { spawn } = require('child_process')
+const kexec = require('kexec')
 const { join } = require('path')
 
 const isNodeArg = (arg) => (
@@ -23,19 +23,4 @@ process.argv.slice(3).forEach((arg) => {
   }
 })
 
-const proc = spawn(
-  process.execPath,
-  args,
-  { stdio: 'inherit' }
-)
-
-proc.on('exit', (code, signal) => {
-  process.on('exit', () => {
-    if (signal) {
-      process.kill(process.pid, signal)
-    } else {
-      process.exit(code)
-    }
-  })
-})
-
+kexec(process.execPath, args)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "file-loader": "^0.9.0",
     "jsdom": "^9.5.0",
     "json-loader": "^0.5.4",
+    "kexec": "^3.0.0",
     "mocha": "^3.0.2",
     "node-sass": "^3.8.0",
     "null-loader": "^0.1.1",


### PR DESCRIPTION
Previous behaviour was `brb` scripts would always end up running two node VMs, one to filter out the  debug arguments, and the other to actually run the script.

I need to be able to reliably terminate the `brb serve` using signals, and the current implementation will terminate the first VM but not the second.

`kexec` gets us the behaviour that we want at the cost of windows compatibility. Another alternative would be to rewrite `bin/index.js` as a shell script (sh has `exec`), but that's also not compatible. Sigh.