### PR TITLE
Webpack dev server disallows using 0.0.0.0 as a host after this patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^0.13.1",
     "webpack": "^1.13.1",
     "webpack-dashboard": "^0.2.0",
-    "webpack-dev-server": "^1.14.1",
+    "webpack-dev-server": "1.16.3",
     "webpack-merge": "^0.14.1",
     "webpack-node-externals": "^1.3.2",
     "yargs": "^4.8.0"


### PR DESCRIPTION
https://github.com/webpack/webpack-dev-server/releases/tag/v1.16.4