### PR TITLE
Iterate and set defaultView props to global in tests

### DIFF
--- a/scripts/test/setup.js
+++ b/scripts/test/setup.js
@@ -3,3 +3,17 @@ const jsdom = require('jsdom')
 global.document = jsdom.jsdom('<html><body></body></html>')
 global.window = document.defaultView
 global.navigator = window.navigator
+
+// properties must be extracted from a document that was created that does not
+// use a vm context.
+const properties = Object.getOwnPropertyNames(
+  jsdom.jsdom('', { features: { ProcessExternalResources: false } }).defaultView
+)
+
+// Attach all window properties to global, so things like HTMLElement are in
+// scope. See https://github.com/sinonjs/sinon/issues/1377
+properties.forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    global[property] = document.defaultView[property]
+  }
+})


### PR DESCRIPTION
This is required to support the calledWithMatch func in Sinon 2.0, which has a dep that complains if HTMLElement doesn't exist.

That part sucks, and should be fixed in Sinon, however, having 'global' in our tests contain the DOM window globals is generally a good thing for a simulated browser test environment.