### PR TITLE
Format connect logger output as json

### DIFF
--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -33,12 +33,12 @@ module.exports = ({
   server.use(logger({
     format: JSON.stringify({
       date: '%date',
-      time: '%time',
+      duration: '%time',
       status: '%status',
       method: '%method',
       url: '%url'
     }),
-    date: 'YYYY-MM-DD HH:mm:ss'
+    date: 'YYYY-MM-DD HH:mm:ss.SSS'
   }))
 
   if (cdnUrl) {

--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -36,7 +36,7 @@ module.exports = ({
       duration: '%time',
       status: '%status',
       method: '%method',
-      url: '%url'
+      path: '%url'
     }),
     date: 'YYYY-MM-DD HH:mm:ss.SSS'
   }))

--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -31,7 +31,14 @@ module.exports = ({
 }) => {
   const baseMatch = new RegExp(`^${basePath}`)
   server.use(logger({
-    format: '[%date - %time] %status %method %url'
+    format: JSON.stringify({
+      date: '%date',
+      time: '%time',
+      status: '%status',
+      method: '%method',
+      url: '%url'
+    }),
+    date: 'YYYY-MM-DD HH:mm:ss'
   }))
 
   if (cdnUrl) {


### PR DESCRIPTION
Example: 

```
{"date":"2017-07-10 13:22:13","time":"37ms","status":"200","method":"GET","url":"/about"}
{"date":"2017-07-10 13:22:13","time":"5ms","status":"304","method":"GET","url":"/dc38dfa71b01bb8adc519a05518480d8.gif"}
{"date":"2017-07-10 13:22:13","time":"8ms","status":"200","method":"GET","url":"/main-254265067093013e0392.css"}
{"date":"2017-07-10 13:22:13","time":"12ms","status":"200","method":"GET","url":"/main-254265067093013e0392.js"}
{"date":"2017-07-10 13:22:18","time":"36ms","status":"200","method":"GET","url":"/"}
{"date":"2017-07-10 13:22:18","time":"1ms","status":"304","method":"GET","url":"/main-254265067093013e0392.js"}
{"date":"2017-07-10 13:22:18","time":"2ms","status":"304","method":"GET","url":"/main-254265067093013e0392.css"}
{"date":"2017-07-10 13:22:18","time":"6ms","status":"200","method":"GET","url":"/6c86efea2bb15496ca8d2a25c7934d63.jpg"}
```

So still to do is use a logger that doesn't default to using terminal colours.