### PR TITLE
Temporary fix for React 16 test execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "ignore": [
       "node_modules"
     ]
+  },
+  "devDependencies": {
+    "raf": "^3.3.2"
   }
 }

--- a/scripts/test/index.js
+++ b/scripts/test/index.js
@@ -5,6 +5,8 @@ const { inputDir = './source' } = require('yargs').argv
 const defaultOpts = [
   '--recursive',
   '--require',
+  'raf/polyfill',
+  '--require',
   join(__dirname, './setup.js'),
   '--compilers',
   `js:${join(__dirname, './compiler.js')}`


### PR DESCRIPTION
React 16 Alpha either is being awful for server-scenarios, or includes a temporary bug where it expects `requestAnimationFrame` to exist. As of Alpha 13, if you don't have requestAnimationFrame, importing ReactDOM fires an assertion failure.

Consequently, Enzyme fails when trying to require ReactDOM and you can't test stuff. Boo.

This fix temporarily loads a requestAnimationFrame polyfill as part of the Mocha initialisation. Client apps can load their own polyfill for running SSR if they want to use React 16.