### PR TITLE
Configure `standard-loader` to use babel-eslint

### DIFF
--- a/config/webpack.shared.config.js
+++ b/config/webpack.shared.config.js
@@ -20,7 +20,12 @@ const rules = [
         loader: 'babel-loader',
         options: babelConfig
       },
-      'standard-loader'
+      {
+        loader: 'standard-loader',
+        options: {
+          parser: 'babel-eslint'
+        }
+      }
     ],
     exclude: /node_modules|dist/
   }


### PR DESCRIPTION
Allows our dev server linting to be able to parse files with `import()` in them