### PR TITLE
Enable specifying custom response headers

### DIFF
--- a/lib/prod-server/__tests__/app-test.js
+++ b/lib/prod-server/__tests__/app-test.js
@@ -36,6 +36,7 @@ describe('app', () => {
   it('should return 404', () => {
     const createApp = require('../app')
     const runner = () => Promise.reject(new Error('Not found'))
+
     const app = createApp({
       enableLogging: false,
       staticDir: '/public',
@@ -47,9 +48,63 @@ describe('app', () => {
       .expect(404)
   })
 
+  it('applies custom headers', () => {
+    const createApp = require('../app')
+    const runner = () => Promise.resolve({
+      headers: {Foo: 'bar'},
+      body: '{ "foo": "bar" }'
+    })
+
+    const app = createApp({
+      enableLogging: false,
+      staticDir: '/public',
+      runner
+    })
+
+    return request(app)
+      .get('/')
+      .expect('Foo', 'bar')
+  })
+
+  it('allows specifying status code', () => {
+    const createApp = require('../app')
+    const runner = () => Promise.resolve({
+      status: 418,
+      body: '{ "foo": "bar" }'
+    })
+
+    const app = createApp({
+      enableLogging: false,
+      staticDir: '/public',
+      runner
+    })
+
+    return request(app)
+      .get('/')
+      .expect(418)
+  })
+
+  it('uses body for response, if result is omitted', () => {
+    const createApp = require('../app')
+    const runner = () => Promise.resolve({
+      body: 'bar'
+    })
+
+    const app = createApp({
+      enableLogging: false,
+      staticDir: '/public',
+      runner
+    })
+
+    return request(app)
+      .get('/')
+      .expect('bar')
+  })
+
   it('should return 500', () => {
     const createApp = require('../app')
     const runner = () => Promise.reject(new Error())
+
     const app = createApp({
       enableLogging: false,
       staticDir: '/public',

--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -3,6 +3,7 @@ const connect = require('connect')
 const mount = require('connect-mount')
 const serveStatic = require('serve-static')
 const logger = require('connect-logger')
+const toPairs = require('lodash/toPairs')
 
 const respondError = (res) => ({ message, stack }) => {
   res.end(`${message}\n${stack}`)
@@ -53,7 +54,7 @@ module.exports = ({
 
   server.use((req, res) => {
     const url = req.url.replace(baseMatch, '/')
-    runner(url).then(({ result, redirect }) => {
+    runner(url).then(({ result, redirect, status = 200, headers = {}, body }) => {
       if (redirect) {
         res.statusCode = 301
         res.setHeader('Location', redirect)
@@ -61,8 +62,17 @@ module.exports = ({
         res.end()
       } else {
         res.setHeader('Content-Type', 'text/html')
-        res.statusCode = 200
-        res.end(result)
+        res.statusCode = status
+
+        toPairs(headers).forEach(([key, value]) => (
+          res.setHeader(key, value)
+        ))
+
+        if (result) {
+          console.warn('`result` has been deprecated and will be removed in a future version of BRB. Please use `body` instead.')
+        }
+
+        res.end(result || body)
       }
     }).catch((error) => {
       if (error.message.match(/^Not found/)) {


### PR DESCRIPTION
This allows us to respond with more than just HTML. Use case: BRB application which is mostly a React app, but also needs to also function as a basic JSON API.