### PR TITLE
404 and 500 routes should have Content-type of text/html also

### DIFF
--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -76,11 +76,13 @@ module.exports = ({
       }
     }).catch((error) => {
       if (error.message.match(/^Not found/)) {
+        res.setHeader('Content-Type', 'text/html')
         res.statusCode = 404
         return runner('/404').then(({ result }) => {
           res.end(result)
         }).catch(respondError(res))
       } else {
+        res.setHeader('Content-Type', 'text/html')
         res.statusCode = 500
         return runner('/500').then(({ result }) => {
           res.end(result)


### PR DESCRIPTION
*Problem*

With the prod server, route not found and other errors are forwarded
back to /404 and /500 respectively. But the Content-type header isn't
being set for these, so in our Lambda setup, they are being served as
application/json

*Solution*

Set the header for these 2 requests to text/html

I noticed this error when testing MyGames, and applied this fix to staging, so these links should help validate the issue.

Production (without fix) - http://www.mygames2018.com/foo
Staging (with fix) - https://2279gftmq5.execute-api.us-east-1.amazonaws.com/staging/foo