### PR TITLE
Add session token to s3 deploy

### DIFF
--- a/lib/deploy/s3/index.js
+++ b/lib/deploy/s3/index.js
@@ -18,7 +18,8 @@ const client = s3.createClient({
   maxAsyncS3: 5,
   s3Options: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN
   }
 })
 


### PR DESCRIPTION
For smaller sites and widgets, we often simply deploy them from our own machine. When using a tool like AWS Vault, it generates temporary credentials and uses a session token, but BRB's S3 deploy doesn't currently use this session token.