### PR TITLE
Lock docker image to node 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 build:
-  image: node:latest
+  image: node:8
   working_dir: /code
   volumes:
     - .:/code


### PR DESCRIPTION
**Problem**

It was previously using node:latest, which at this time, is 10 point something. The npm login does not work the same way so the CI was broken. I was able to replicate the issue locally in node 10/npm 6.

**Solution**

Just lock down the docker image to node 8, rather than have things changing underneath us.