### PR TITLE
Fix naming in Lambda deploy to work with recent changes

### DIFF
--- a/lib/deploy/lambda/index.js
+++ b/lib/deploy/lambda/index.js
@@ -54,7 +54,7 @@ class LambdaDeploy {
 
   generateLambdaWrapper () {
     return new Promise((resolve) => {
-      getPreviousResult(this.brbBuildFile, ({ assets, app_path: appPath }) => {
+      getPreviousResult(this.brbBuildFile, ({ assets, appPath }) => {
         this.appBasename = basename(appPath)
         const handlerFileContent = fs.readFileSync(`${__dirname}/templates/lambda_wrapper`, 'utf8')
         const lambdaContent = handlerFileContent.replace(/ASSETS/, JSON.stringify(assets))
@@ -65,7 +65,7 @@ class LambdaDeploy {
     })
   }
 
-  createArchive ({ lambdaContent, app_path: appPath }) {
+  createArchive ({ lambdaContent, appPath }) {
     return new Promise((resolve, reject) => {
       const resultingFolder = join(process.cwd(), '.lambda')
       mkdirp.sync(resultingFolder)


### PR DESCRIPTION
There were recent changes in BRB that affected the naming in various places - https://github.com/everydayhero/boiler-room-builder/commit/eca568c02c1df8a1886fe17bdceec356888cb7b4

This meant the Lambda deploy was broken, as it was still destructuring objects based on the old naming.