### PR TITLE
Log errors in prod server

### DIFF
--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -76,6 +76,8 @@ module.exports = ({
         res.end(result || body)
       }
     }).catch((error) => {
+      console.log(error)
+
       if (error.message.match(/^Not found/)) {
         res.setHeader('Content-Type', 'text/html')
         res.statusCode = 404

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boiler-room-builder",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
When an error occurs, it renders the /500 route correctly, but just swallows up the error.