### PR TITLE
Pass full connect request object to runner function

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The returned function will take a route return a Promise which may:
 
 ```
 export default ({ assets = [] }) =>
-  (route = '/') =>
+  (route = '/', request = {}) =>
     Promise.resolve({
       result: '<html />',
       // OR
@@ -282,4 +282,4 @@ and Standard 12.x. Please refer to the docs for each individual dependency for h
 The most outward facing change to look out for is that as of Babel 7, `babel-preset-stage-0` no longer exists. Babel's
 recommendation is to explicitly import on any experimental features you need. You probably aren't using a `stage`
 feature in your app, but if you are you'll need to include the specific transform or plugin from Babel in your own
-app's Babel config. 
+app's Babel config.

--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -57,8 +57,7 @@ module.exports = ({
 
   server.use((req, res) => {
     const url = req.url.replace(baseMatch, '/')
-    const headers = req.headers
-    runner(url, headers).then(({ result, redirect, status = 200, headers = {}, body }) => {
+    runner(url, req).then(({ result, redirect, status = 200, headers = {}, body }) => {
       if (redirect) {
         res.statusCode = 301
         res.setHeader('Location', redirect)


### PR DESCRIPTION
**This is a potentially breaking change if you were previously using the headers argument in your app**

Previously were were passing `req.headers` as a second argument to the provided `runner` method. In the case we want to support, for example, POST request body parsing in our apps, we'll need access to the request body.