### PR TITLE
Static site plugin should also use body

### DIFF
--- a/plugins/static-site-plugin/index.js
+++ b/plugins/static-site-plugin/index.js
@@ -18,13 +18,17 @@ module.exports = class {
         const routes = runner.staticRoutes || ['/']
 
         return Promise.all(routes.map((route) => (
-          runner(route).then(({ result }) => {
+          runner(route).then(({ body, result }) => {
+            if (result) {
+              console.warn('`result` has been deprecated and will be removed in a future version of BRB. Please use `body` instead.')
+            }
+
             assets[path.join(route.slice(1), 'index.html')] = {
               source () {
-                return result
+                return result || body
               },
               size () {
-                return result.length
+                return (result || body).length
               }
             }
           })


### PR DESCRIPTION
The prod-server now expects the returned body to use the `body` key, and if it uses the soon to be deprecated `result`, it issues a warning, but still works.

BRR was recently updated in accordance with this warning to use `body` instead of `result`.

The issue is that the static site plugin has always only ever worked with `result`, and this meant that static site generation was broken when using the latest version of BRR. So I have updated the site static site plugin to use `body`, and issue a warning if `result` is used, in the same way the prod server does.

This way when we deprecate `result`, we can just remove it from both the prod server and the static site plugin.