### PR TITLE
Pass req through to runner for error routes as well

### DIFF
--- a/lib/prod-server/app.js
+++ b/lib/prod-server/app.js
@@ -93,13 +93,13 @@ module.exports = ({
       if (error.message.match(/^Not found/)) {
         res.setHeader('Content-Type', 'text/html')
         res.statusCode = 404
-        return runner('/404').then(({ result }) => {
+        return runner('/404', req).then(({ result }) => {
           res.end(result)
         }).catch(respondError(res))
       } else {
         res.setHeader('Content-Type', 'text/html')
         res.statusCode = 500
-        return runner('/500').then(({ result }) => {
+        return runner('/500', req).then(({ result }) => {
           res.end(result)
         }).catch(respondError(res))
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boiler-room-builder",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
When calling `runner`, it passes through the current path as the first param and the whole request object as the second arg. If an error is caught, it re-calls runner passing in either `/404` or `/500` as the path (allowing you to show error pages from within the app), but we aren't passing through the request object in these cases, meaning we hit issues in our server.js if we tried to interact with this request object.