### PR TITLE
[RELEASE] Modify the typescript support to be 'either or' to simplify linting

### DIFF
--- a/config/webpack.shared.config.js
+++ b/config/webpack.shared.config.js
@@ -13,7 +13,7 @@ const fileLoaders = extensionsFlat.map((ext) => ({
   use: 'file-loader'
 }))
 
-const rules = [
+const javascriptRules = [
   {
     test: /\.(js|jsx)?$/,
     use: [
@@ -29,9 +29,12 @@ const rules = [
       }
     ],
     exclude: /node_modules|dist/
-  },
+  }
+].concat(fileLoaders)
+
+const typescriptRules = [
   {
-    test: /\.(ts|tsx)?$/,
+    test: /\.(js|jsx|ts|tsx)?$/,
     use: [
       {
         loader: 'babel-loader',
@@ -47,8 +50,10 @@ const rules = [
 
 const plugins = []
 
-module.exports = {
-  stats: { children: false },
-  module: { rules },
-  plugins
+module.exports = (supportTypescript = false) => {
+  return {
+    stats: { children: false },
+    plugins,
+    module: { rules: supportTypescript ? typescriptRules : javascriptRules }
+  }
 }

--- a/lib/create-configs/index.js
+++ b/lib/create-configs/index.js
@@ -14,7 +14,7 @@ const PROD = process.env.NODE_ENV === 'production'
 const { assign } = Object
 
 const trimPath = (path = '') => (
-  path.replace().replace(/^\/|\/$/g, '')
+  path.replace(/^\/|\/$/g, '')
 )
 
 const ensureAbsolute = (path = '') => {
@@ -73,7 +73,8 @@ module.exports = ({
   dev = {},
   middleware = { middlewares: [] },
   outputToBase,
-  forLambda
+  forLambda,
+  supportTypescript = false
 } = {}) => {
   const config = {
     inputDir,
@@ -84,7 +85,7 @@ module.exports = ({
   }
 
   const sharedConfig = smarterMerge(
-    defaultShared,
+    defaultShared(supportTypescript),
     shared
   )
   const serverConfig = applyConfig(

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -11,7 +11,8 @@ const {
   serverConfig: serverConfigPath,
   clientConfig: clientConfigPath,
   outputToBase = false,
-  forLambda = false
+  forLambda = false,
+  supportTypescript = false
 } = require('yargs').argv
 
 const client = clientConfigPath
@@ -36,7 +37,8 @@ const {
   server,
   shared,
   outputToBase,
-  forLambda
+  forLambda,
+  supportTypescript
 })
 
 build({

--- a/scripts/serve/index.js
+++ b/scripts/serve/index.js
@@ -13,7 +13,8 @@ const {
   devConfig: devConfigPath,
   middlewareConfig: middlewareConfigPath,
   port = 8080,
-  outputToBase = false
+  outputToBase = false,
+  supportTypescript = false
 } = require('yargs').argv
 
 const client = clientConfigPath
@@ -49,7 +50,8 @@ const {
   shared,
   dev,
   middleware,
-  outputToBase
+  outputToBase,
+  supportTypescript
 })
 
 serve({


### PR DESCRIPTION
- The typescript config is pretty similar to the javascript config, in that it's still babel just with a couple of extra plugins
- The main difference (other than supporting ts at all) is we use eslint and the typescript-with-standard eslint plugin rather than the standard library wrapper
- It produces less weird linting errors in the user if we *either* use eslint-loader or standard-loader, not one or the other depending on the .ts or .js extension.
- So that legacy support doesn't break here, typescript config is now opt-in on a flag.