### PR TITLE
Include async build config option for webpack config

### DIFF
--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -3,14 +3,25 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin')
 const StaticSitePlugin = require('../../plugins/static-site-plugin')
 const appFromStats = require('../app-from-stats')
 const persistBuildResult = require('./persist-build-result')
+const merge = require('webpack-merge')
 
 const progress = new ProgressBarPlugin()
 
-module.exports = ({
+module.exports = async ({
   serverConfig = {},
-  clientConfig
+  clientConfig,
+  asyncConfig
 }, callback = () => {}) => {
-  const serverCompiler = webpack(serverConfig)
+  const buildConfig = typeof asyncConfig === 'function'
+    ? await asyncConfig()
+    : asyncConfig
+
+  const config = merge.smart(
+    serverConfig,
+    buildConfig
+  )
+
+  const serverCompiler = webpack(config)
 
   serverCompiler.apply(progress)
 

--- a/lib/create-configs/index.js
+++ b/lib/create-configs/index.js
@@ -72,6 +72,7 @@ module.exports = ({
   client = {},
   dev = {},
   middleware = { middlewares: [] },
+  asyncBuildConfig: asyncConfig,
   outputToBase,
   forLambda,
   supportTypescript = false
@@ -123,6 +124,7 @@ module.exports = ({
     clientConfig,
     serverConfig,
     devConfig,
-    middlewaresConfig
+    middlewaresConfig,
+    asyncConfig
   }
 }

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -10,6 +10,7 @@ const {
   config: sharedConfigPath,
   serverConfig: serverConfigPath,
   clientConfig: clientConfigPath,
+  asyncBuildConfig: asyncConfigPath,
   outputToBase = false,
   forLambda = false,
   supportTypescript = false
@@ -24,10 +25,14 @@ const server = serverConfigPath
 const shared = sharedConfigPath
   ? require(join(process.cwd(), sharedConfigPath))
   : {}
+const asyncBuildConfig = asyncConfigPath
+  ? require(join(process.cwd(), asyncConfigPath))
+  : {}
 
 const {
   clientConfig,
-  serverConfig
+  serverConfig,
+  asyncConfig
 } = createConfigs({
   inputDir,
   outputDir,
@@ -36,6 +41,7 @@ const {
   client,
   server,
   shared,
+  asyncBuildConfig,
   outputToBase,
   forLambda,
   supportTypescript
@@ -46,5 +52,6 @@ build({
   outputDir,
   basePath,
   clientConfig,
-  serverConfig
+  serverConfig,
+  asyncConfig
 })


### PR DESCRIPTION
**Problem:**

We cannot currently specify any Webpack config that is a function or returns a promise. I need this to be able to fetch data to pass to a [sitemap plugin](https://www.npmjs.com/package/sitemap-webpack-plugin).

**Solution:**
```
brb build --async-build-config='./webpack.build.config'
```

As per the [Webpack docs](https://webpack.js.org/configuration/configuration-types/#exporting-a-promise) (highlighting is mine):

> Returning a Promise only works when using webpack via CLI. **webpack() expects an object.**

Based on the [suggestion here](https://stackoverflow.com/questions/43327486/async-webpack-config), we can resolve the promise and then pass the resulting config object.

I also tried working with the existing configs, but the existing merge didn't quite work and I didn't want to break things, hence adding the new option in.